### PR TITLE
Fixed label hash conversion padding issue on frontend

### DIFF
--- a/src/reducers/_account.js
+++ b/src/reducers/_account.js
@@ -103,7 +103,13 @@ export const accountGetTokenizedDomains = () => (dispatch, getState) => {
       if (tokens.length) {
         tokens = tokens.map(token => ({
           domain: '',
-          labelHash: web3Instance.utils.toHex(token),
+          labelHash:
+            '0x' +
+            web3Instance.utils
+              .toHex(token)
+              .toLowerCase()
+              .replace('0x', '')
+              .padStart(64, '0'),
         }));
         tokens = await Promise.all(
           tokens.map(async token => {


### PR DESCRIPTION
Similar issue earlier where a converted tokenId would miss padding in the front.
We missed this fix on the front end when getting a user's tokens.

Should resolve #51.